### PR TITLE
Refactor Board type

### DIFF
--- a/src/Hive.hs
+++ b/src/Hive.hs
@@ -23,6 +23,7 @@ import Hive.Command as X
 import Hive.Coordinate as X
 import Hive.Piece as X
 import Hive.Player as X
+import qualified Hive.Utils.Set as Set
 
 -- | The state of a Hive game.
 data HiveState = HiveState
@@ -107,7 +108,7 @@ updateState HiveState{..} Command{..} = checkValid >> pure nextState
         unless (commandPosition `elem` getValidMoves board currPiece) $ Left ViolatesPieceRules
       else checkWillTouchOtherPlayer
     checkWillTouchOtherPlayer = when
-      (anySet ((== otherPlayer) . fst) $ getSurroundingPieces board commandPosition)
+      (Set.any ((== otherPlayer) . fst) $ getSurroundingPieces board commandPosition)
       $ Left CannotAddNextToOpponent
 
 -- | Get all the valid moves for the given piece.
@@ -122,9 +123,3 @@ getValidMoves board playerPiece@(player, _) = case getPosition board playerPiece
     getValidFrom currPosition = undefined
     -- Queries
     isTouchingOpponent coord = any ((/= player) . fst) $ getSurroundingPieces board coord
-
-{- Helpers -}
-
--- | 'any' for sets.
-anySet :: Ord a => (a -> Bool) -> Set a -> Bool
-anySet f = not . Set.null . Set.filter f

--- a/src/Hive.hs
+++ b/src/Hive.hs
@@ -14,7 +14,9 @@ module Hive
   ) where
 
 import Control.Monad (unless, when)
-import Data.Maybe (fromJust, fromMaybe, isJust, isNothing)
+import Data.Maybe (fromJust, isJust)
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 import Hive.Board as X
 import Hive.Command as X
@@ -24,7 +26,7 @@ import Hive.Player as X
 
 -- | The state of a Hive game.
 data HiveState = HiveState
-  { board     :: HiveBoard
+  { board     :: Board
   , player    :: Player
   , hiveRound :: Int -- ^ Increments after both players have gone
   } deriving (Show)
@@ -47,9 +49,9 @@ getResult HiveState{board} = case (isDead One, isDead Two) of
   (True, False) -> Just $ Win Two
   (True, True) -> Just Draw
   where
-    isDead p = case getPosition board (p, Bee) of
+    isDead p = case getCoordinate board (p, Bee) of
       Nothing -> False
-      Just (beeCoordinates, _) -> length (getSurroundingPieces board beeCoordinates) == 6
+      Just beeCoordinates -> length (getSurroundingPieces board beeCoordinates) == 6
 
 data InvalidCommand
   = NeedToPlaceBee            -- ^ When it's round 4 and the bee has not been placed
@@ -70,14 +72,12 @@ updateState HiveState{..} Command{..} = checkValid >> pure nextState
   where
     otherPlayer = if isPlayerOne then Two else One
     currPiece = (player, commandPiece)
-    currPosition = getPosition board currPiece
+    isCurrOnBoard = isOnBoard board currPiece
     nextSpotPiece = getPiece board commandPosition
     commandPieceType = pieceToType commandPiece
     -- Next state
-    nextHeight = fromMaybe 0 $ ((+ 1) . snd) <$> nextSpotPiece
-    nextPosition = (commandPosition, nextHeight)
     nextState = HiveState
-      { board = putPiece board currPiece nextPosition
+      { board = putPiece currPiece commandPosition board
       , player = otherPlayer
       , hiveRound = if isPlayerOne then hiveRound else hiveRound + 1
       }
@@ -91,34 +91,40 @@ updateState HiveState{..} Command{..} = checkValid >> pure nextState
       else sequence_ [checkLeave, checkValidMovement]
     checkStart = do
       when (hiveRound == 3 && commandPiece /= Bee) $ Left NeedToPlaceBee
-      unless (isNothing currPosition) $ Left CannotMoveWithoutBee
+      unless (not isCurrOnBoard) $ Left CannotMoveWithoutBee
       when (hiveRound > 0) checkWillTouchOtherPlayer
-    checkLeave = case currPosition of
+    checkLeave = case getPosition board currPiece of
       Nothing -> return ()
       Just (coordinate, height) -> do
         let topMostHeight = snd $ fromJust $ getPiece board coordinate
         unless (height == topMostHeight) $ Left CannotMoveFromUnderneath
-        when (height == 0 && not (isHiveWithout board currPiece)) $ Left CannotBreakHive
-    checkValidMovement = case currPosition of
-      Nothing -> checkWillTouchOtherPlayer
-      Just _ -> do
+        when (height == 0 && not (isHive $ removePiece currPiece board)) $ Left CannotBreakHive
+    checkValidMovement = if isCurrOnBoard
+      then do
         unless (commandPieceType == BeetleType || not isNextSpotOccupied)
           $ Left CannotMoveToOccupied
-        unless (commandPosition `elem` getBorderWithout board currPiece) $ Left CannotMoveOffHive
+        unless (commandPosition `elem` getBorder (removePiece currPiece board)) $ Left CannotMoveOffHive
         unless (commandPosition `elem` getValidMoves board currPiece) $ Left ViolatesPieceRules
+      else checkWillTouchOtherPlayer
     checkWillTouchOtherPlayer = when
-      (any ((== otherPlayer) . fst) $ getSurroundingPieces board commandPosition)
+      (anySet ((== otherPlayer) . fst) $ getSurroundingPieces board commandPosition)
       $ Left CannotAddNextToOpponent
 
 -- | Get all the valid moves for the given piece.
 --
 -- If the piece is not on the board, get the possible positions to put the piece.
-getValidMoves :: HiveBoard -> PlayerPiece -> [Coordinate]
+getValidMoves :: Board -> PlayerPiece -> Set Coordinate
 getValidMoves board playerPiece@(player, _) = case getPosition board playerPiece of
   Nothing -> getValidSpotsOnBorder
   Just pos -> getValidFrom pos
   where
-    getValidSpotsOnBorder = filter (not . isTouchingOpponent) $ getBorderWithout board playerPiece
+    getValidSpotsOnBorder = Set.filter (not . isTouchingOpponent) $ getBorder (removePiece playerPiece board)
     getValidFrom currPosition = undefined
     -- Queries
     isTouchingOpponent coord = any ((/= player) . fst) $ getSurroundingPieces board coord
+
+{- Helpers -}
+
+-- | 'any' for sets.
+anySet :: Ord a => (a -> Bool) -> Set a -> Bool
+anySet f = not . Set.null . Set.filter f

--- a/src/Hive/Board.hs
+++ b/src/Hive/Board.hs
@@ -34,13 +34,14 @@ import Data.Function (on)
 import Data.List (sortBy)
 import Data.Map.Strict (Map, (!), (!?))
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust, isJust)
+import Data.Maybe (isJust)
 import Data.Set (Set, (\\))
 import qualified Data.Set as Set
 
 import Hive.Coordinate (Coordinate, Neighbors, getNeighborhood, getNeighbors, toNeighborhood)
 import Hive.Piece (Piece, allPieces)
 import Hive.Player (Player(..))
+import qualified Hive.Utils.Set as Set
 
 {- Auxiliary types -}
 
@@ -152,7 +153,7 @@ getSurrounding board = fmap (getPiece' board) . getNeighbors
 
 -- | Get the surrounding pieces for the given coordinate.
 getSurroundingPieces :: Board -> Coordinate -> Set PlayerPiece
-getSurroundingPieces = catMaybesSet . toNeighborhood .: getSurrounding
+getSurroundingPieces = Set.catMaybes . toNeighborhood .: getSurrounding
 
 {- Board predicates -}
 
@@ -183,10 +184,6 @@ isOnBoard :: Board -> PlayerPiece -> Bool
 isOnBoard = isJust .: getPosition
 
 {- Helpers -}
-
--- | 'catMaybes' for Set
-catMaybesSet :: Ord a => Set (Maybe a) -> Set a
-catMaybesSet = Set.map fromJust . Set.filter isJust
 
 (.:) :: (z -> c) -> (a -> b -> z) -> a -> b -> c
 (.:) = (.) . (.)

--- a/src/Hive/Board.hs
+++ b/src/Hive/Board.hs
@@ -41,6 +41,7 @@ import qualified Data.Set as Set
 import Hive.Coordinate (Coordinate, Neighbors, getNeighborhood, getNeighbors, toNeighborhood)
 import Hive.Piece (Piece, allPieces)
 import Hive.Player (Player(..))
+import Hive.Utils.Composition ((.:))
 import qualified Hive.Utils.Set as Set
 
 {- Auxiliary types -}
@@ -182,9 +183,3 @@ isOccupied board = isJust . getPiece' board
 -- | Return True if the given piece is on the board.
 isOnBoard :: Board -> PlayerPiece -> Bool
 isOnBoard = isJust .: getPosition
-
-{- Helpers -}
-
-(.:) :: (z -> c) -> (a -> b -> z) -> a -> b -> c
-(.:) = (.) . (.)
-infixl 4 .: -- same fixity as <$>

--- a/src/Hive/Board.hs
+++ b/src/Hive/Board.hs
@@ -85,22 +85,22 @@ coordinateMap = Map.map orderHeight . invert . Map.mapMaybe id . pieceMap
 
 -- | Add or move the given piece to the given coordinate.
 putPiece :: PlayerPiece -> Coordinate -> Board -> Board
-putPiece piece coordinate oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
+putPiece piece newSpot oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
   newBoard { border = newBorder }
   where
-    newBoard = oldBoard { pieceMap = Map.insert piece (Just (coordinate, height)) oldMap }
-    height = maybe 0 ((+ 1) . snd) $ getPiece oldBoard coordinate
+    oldSpot = getCoordinate oldBoard piece
+    newBoard = oldBoard { pieceMap = Map.insert piece (Just (newSpot, height)) oldMap }
+    height = maybe 0 ((+ 1) . snd) $ getPiece oldBoard newSpot
     newBorder =
-      Set.delete coordinate
+      Set.delete newSpot
+      . Set.union (Set.fromMaybe oldSpot)
       . Set.union unoccupiedNeighbors
       . (`Set.difference` prevNeighbors)
       $ oldBorder
     -- all unoccupied neighbors of new position
-    unoccupiedNeighbors = Set.filter (not . isOccupied oldBoard) $ getNeighborhood coordinate
+    unoccupiedNeighbors = Set.filter (not . isOccupied oldBoard) $ getNeighborhood newSpot
     -- all neighbors of previous position that don't have any other occupied neighbors
-    prevNeighbors = case getCoordinate oldBoard piece of
-      Nothing -> Set.empty
-      Just prev -> getNeighborsWithoutNeighbors newBoard prev
+    prevNeighbors = maybe Set.empty (getNeighborsWithoutNeighbors newBoard) oldSpot
 
 -- | Remove the given piece from the board.
 --

--- a/src/Hive/Board.hs
+++ b/src/Hive/Board.hs
@@ -105,6 +105,8 @@ putPiece piece newSpot oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
 -- | Remove the given piece from the board.
 --
 -- Doesn't occur in an actual game, but useful for figuring out mechanics mid-move.
+--
+-- Satisfies @removePiece piece . putPiece piece coord = id@
 removePiece :: PlayerPiece -> Board -> Board
 removePiece piece oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
   newBoard { border = newBorder }
@@ -113,7 +115,7 @@ removePiece piece oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
     newBorder = case getCoordinate oldBoard piece of
       Nothing -> oldBorder
       Just coordinate ->
-        Set.insert coordinate
+        (if hasNeighbors oldBoard coordinate then Set.insert coordinate else id)
         . (`Set.difference` getNeighborsWithoutNeighbors newBoard coordinate)
         $ oldBorder
 

--- a/src/Hive/Board.hs
+++ b/src/Hive/Board.hs
@@ -25,12 +25,12 @@ module Hive.Board
   , isOccupied
   ) where
 
-import Control.Monad (join, (<=<))
+import Control.Monad ((<=<))
 import Data.Function (on)
-import Data.List (nub, sortBy)
+import Data.List (sortBy)
 import Data.Map.Strict (Map, (!), (!?))
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromJust, isJust)
+import Data.Maybe (fromJust, isJust)
 import Data.Set (Set, (\\))
 import qualified Data.Set as Set
 
@@ -100,17 +100,16 @@ putPiece piece coordinate oldBoard@Board{pieceMap = oldMap, border = oldBorder} 
 --
 -- Doesn't occur in an actual game, but useful for figuring out mechanics mid-move.
 removePiece :: PlayerPiece -> Board -> Board
-removePiece piece oldBoard@Board{pieceMap = oldMap, border = oldBorder} = board
-  { pieceMap = newMap
-  , border = newBorder
-  }
+removePiece piece oldBoard@Board{pieceMap = oldMap, border = oldBorder} =
+  newBoard { border = newBorder }
   where
-    newBoard = board { pieceMap = Map.insert piece Nothing oldMap }
-    coordinate = fst $ oldMap ! piece
-    newBorder =
-      Set.add coordinate
-      . (`Set.difference` getNeighborsWithoutNeighbors newBoard coordinate)
-      $ oldBorder
+    newBoard = oldBoard { pieceMap = Map.insert piece Nothing oldMap }
+    newBorder = case oldMap ! piece of
+      Nothing -> oldBorder
+      Just (fst -> coordinate) ->
+        Set.insert coordinate
+        . (`Set.difference` getNeighborsWithoutNeighbors newBoard coordinate)
+        $ oldBorder
 
 {- Board queries -}
 
@@ -163,72 +162,10 @@ isHive Board{pieceMap} = case occupiedSpots of
 isOccupied :: Board -> Coordinate -> Bool
 isOccupied board = isJust . getPiece' board
 
-{- Functions -}
-
--- | Returns a board without the given piece.
-without :: BoardLike b => b -> PlayerPiece -> Board
-without = flip Map.delete . toBoard
-
--- | Returns True if the given piece is on the board.
-isOnBoard :: BoardLike b => b -> PlayerPiece -> Bool
-isOnBoard = isJust .: getPosition
-
--- | Returns True if the board is still a contiguous hive without the given piece.
-isHiveWithout :: BoardLike b => b -> PlayerPiece -> Bool
-isHiveWithout (toBoard -> board) piece = case getOccupiedSpots (board `without` piece) of
-  [] -> True -- no other piece is on the board (e.g. the first round)
-  (x:xs) -> isHive [x] $ Set.fromList xs
-  where
-    isHive _ (Set.null -> True) = True
-    isHive [] _ = False
-    isHive (x:todo) rest =
-      let found = Set.intersection (getNeighbors' x) rest
-      in isHive (todo ++ Set.toList found) $ rest \\ found
-
--- | Puts the given piece to the given Position.
-putPiece :: HiveBoard -> PlayerPiece -> Position -> HiveBoard
-putPiece (HiveBoard board) piece coordinate = HiveBoard $ Map.insert piece (Just coordinate) board
-
--- | Get the board as a map from Coordinate to a list of PlayerPieces, where the head of the
--- list is the top-most piece of the Coordinate.
-getFlippedBoard :: BoardLike b => b -> Map Coordinate [PlayerPiece]
-getFlippedBoard = Map.map orderHeight . Map.fromListWith (++) . mapMaybe swap . Map.toList . toBoard
-  where
-    swap (_, Nothing) = Nothing
-    swap (piece, Just (coord, height)) = Just (coord, [(height, piece)])
-    orderHeight = map snd . sortBy (compare `on` fst)
-
--- | Get all occupied coordinates on the board.
-getOccupiedSpots :: BoardLike b => b -> [Coordinate]
-getOccupiedSpots = nub . Map.elems . Map.mapMaybe (fmap fst) . toBoard
-
--- | Get the position of the given piece.
-getPosition :: BoardLike b => b -> PlayerPiece -> Maybe Position
-getPosition (toBoard -> board) piece = join $ Map.lookup piece board
-
--- | Get the top-most piece at the given coordinate and its height.
-getPiece :: BoardLike b => b -> Coordinate -> Maybe (PlayerPiece, Int)
-getPiece board = (`Map.lookup` getFlippedBoard board) >=> getTop
-  where
-    getTop [] = Nothing
-    getTop l@(x:_) = Just (x, length l - 1)
-
--- | Get the top-most piece at the given coordinate.
-getPiece' :: BoardLike b => b -> Coordinate -> Maybe PlayerPiece
-getPiece' = fmap fst .: getPiece
-
--- | Get the coordinates around the hive without the given piece.
-getBorderWithout :: BoardLike b => b -> PlayerPiece -> [Coordinate]
-getBorderWithout (toBoard -> board) piece =
-  filter (`notElem` occupiedSpots) . getAllNeighbors $ occupiedSpots
-  where
-    occupiedSpots = getOccupiedSpots (board `without` piece)
-    getAllNeighbors = nub . concatMap getNeighbors'
-
 {- Helpers -}
 
 -- | 'catMaybes' for Set
-catMaybesSet :: Set (Maybe a) -> Set a
+catMaybesSet :: Ord a => Set (Maybe a) -> Set a
 catMaybesSet = Set.map fromJust . Set.filter isJust
 
 (.:) :: (z -> c) -> (a -> b -> z) -> a -> b -> c

--- a/src/Hive/Coordinate.hs
+++ b/src/Hive/Coordinate.hs
@@ -5,8 +5,8 @@ module Hive.Coordinate
   ( Coordinate
   , Neighbors(..)
   , getNeighbors
-  , getNeighbors'
   , toNeighborhood
+  , getNeighborhood
   ) where
 
 import Data.Set (Set)
@@ -51,10 +51,11 @@ getNeighbors (x, y) = Neighbors
   , northwest = (x - 1, y)
   }
 
--- | Get the coordinates surrounding the given coordinate, without caring about order.
-getNeighbors' :: Coordinate -> Set Coordinate
-getNeighbors' = Set.fromList . toNeighborhood . getNeighbors
+-- | Convert neighbors to a set.
+toNeighborhood :: Ord a => Neighbors a -> Set a
+toNeighborhood Neighbors{..} = Set.fromList
+  [north, northeast, southeast, south, southwest, northwest]
 
--- | Convert neighbors to a list.
-toNeighborhood :: Neighbors a -> [a]
-toNeighborhood Neighbors{..} = [north, northeast, southeast, south, southwest, northwest]
+-- | Get the coordinates surrounding the given coordinate, without caring about order.
+getNeighborhood :: Coordinate -> Set Coordinate
+getNeighborhood = toNeighborhood . getNeighbors

--- a/src/Hive/Coordinate.hs
+++ b/src/Hive/Coordinate.hs
@@ -9,6 +9,9 @@ module Hive.Coordinate
   , toNeighborhood
   ) where
 
+import Data.Set (Set)
+import qualified Data.Set as Set
+
 -- | A coordinate on the Hive board.
 --
 -- The origin is arbitrary; all that matters are the coordinates'
@@ -49,8 +52,8 @@ getNeighbors (x, y) = Neighbors
   }
 
 -- | Get the coordinates surrounding the given coordinate, without caring about order.
-getNeighbors' :: Coordinate -> [Coordinate]
-getNeighbors' = toNeighborhood . getNeighbors
+getNeighbors' :: Coordinate -> Set Coordinate
+getNeighbors' = Set.fromList . toNeighborhood . getNeighbors
 
 -- | Convert neighbors to a list.
 toNeighborhood :: Neighbors a -> [a]

--- a/src/Hive/Utils/Composition.hs
+++ b/src/Hive/Utils/Composition.hs
@@ -1,0 +1,7 @@
+module Hive.Utils.Composition
+  ( (.:)
+  ) where
+
+(.:) :: (z -> c) -> (a -> b -> z) -> a -> b -> c
+(.:) = (.) . (.)
+infixl 4 .: -- same fixity as <$>

--- a/src/Hive/Utils/Set.hs
+++ b/src/Hive/Utils/Set.hs
@@ -1,6 +1,7 @@
 module Hive.Utils.Set
   ( any
   , catMaybes
+  , fromMaybe
   ) where
 
 import Data.Maybe (fromJust, isJust)
@@ -13,3 +14,6 @@ any f = not . Set.null . Set.filter f
 
 catMaybes :: Ord a => Set (Maybe a) -> Set a
 catMaybes = Set.map fromJust . Set.filter isJust
+
+fromMaybe :: Maybe a -> Set a
+fromMaybe = maybe Set.empty Set.singleton

--- a/src/Hive/Utils/Set.hs
+++ b/src/Hive/Utils/Set.hs
@@ -1,0 +1,15 @@
+module Hive.Utils.Set
+  ( any
+  , catMaybes
+  ) where
+
+import Data.Maybe (fromJust, isJust)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Prelude hiding (any)
+
+any :: Ord a => (a -> Bool) -> Set a -> Bool
+any f = not . Set.null . Set.filter f
+
+catMaybes :: Ord a => Set (Maybe a) -> Set a
+catMaybes = Set.map fromJust . Set.filter isJust


### PR DESCRIPTION
Now the Board type caches the border, which is built up every time a piece is added to/removed from the board.

Also adds the ability to remove a piece from the board, which isn't useful during the game, but useful for intermediate computations