### PR TITLE
Use Travis CI instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ aliases:
   - &run-build-ghc
     run:
       name: Build package
-      command: stack build --test --no-run-tests
+      command: stack build -j1 --test --no-run-tests
       no_output_timeout: 30m
   - &run-build-ghcjs
     run:

--- a/scripts/install-stack-deps.sh
+++ b/scripts/install-stack-deps.sh
@@ -9,6 +9,5 @@ if [[ "${NO_GHC:-}" != "true" ]]; then
 fi
 
 # needs to be installed explicitly first for linux
-ghcjs/stack.sh build ghcjs-dom-jsffi
-ghcjs/stack.sh build --test --only-dependencies
+ghcjs/stack.sh build -j1 --test --only-dependencies
 stack build hlint stylish-haskell


### PR DESCRIPTION
Circle CI is having some potential memory problems. Trying out Travis, since it seems like more Haskell projects use Travis than Circle.