### PR TITLE
Build with ghcjs in EC2 instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ aliases:
     docker:
       - image: centos:7
     working_directory: /root/src
+    shell: bash -ex -o pipefail
 
   # caches
   - &build-ghc-cache-key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ aliases:
     docker:
       - image: centos:7
     working_directory: /root/src
+    environment:
+      CI_FILES: /root/.ci/
 
   # caches
   - &build-ghc-cache-key
@@ -34,7 +36,7 @@ aliases:
   - &ghc-cache-key
     v0-{{ checksum "ghc-cache-key.txt" }}
   - &ghcjs-cache-key
-    v0-{{ checksum "ghcjs-cache-key.txt" }}
+    v0.1-{{ checksum "ghcjs-cache-key.txt" }}
 
   # dependencies
   - &install-system-deps
@@ -46,10 +48,20 @@ aliases:
       name: Build stack dependencies
       command: scripts/install-stack-deps.sh
       no_output_timeout: 30m
-  - &install-terraform
+  - &install-remote-deps
     run:
-      name: Install Terraform
-      command: scripts/install-terraform.sh
+      name: Install dependencies for building remotely
+      command: |
+        scripts/install-terraform.sh
+
+        # install aws cli
+        curl -O https://bootstrap.pypa.io/get-pip.py
+        python get-pip.py
+        pip install awscli
+        aws configure set region us-west-2
+
+        # install ssh commands
+        yum install -y openssh-clients
 
   # build steps
   - &run-build-ghc
@@ -63,24 +75,36 @@ aliases:
     run:
       name: Spin up remote build server
       command: |
+        mkdir -p "$CI_FILES"
+
         terraform init
         terraform apply --auto-approve
+        REMOTE_IP=$(terraform output ip)
+        echo "export REMOTE_IP=${REMOTE_IP}" >> "$BASH_ENV"
 
         # get pem key
-        curl -O https://bootstrap.pypa.io/get-pip.py
-        python get-pip.py
-        pip install awscli
-        aws s3 cp s3://hive-ci/hive-ci.pem .
-        chmod 600 hive-ci.pem
+        aws s3 cp s3://hive-ci/hive-ci.pem "$CI_FILES"
+        chmod 600 "${CI_FILES}/hive-ci.pem"
+
+        # wait for instance to boot up
+        aws ec2 wait instance-running --filters "Name=ip-address,Values=${REMOTE_IP}"
+
+        # register host
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        ssh-keyscan -H "$REMOTE_IP" >> ~/.ssh/known_hosts
       working_directory: /root/src/.circleci/
   - &upload-ghcjs-cache
     run:
       name: Upload GHCJS cache
-      command: echo upload-ghcjs-cache
+      command: |
+        scp -i "${CI_FILES}/hive-ci.pem" \
+          ~/ghcjs-cache.tar.gz \
+          .circleci/run-remote-build.sh \
+          "ec2-user@${REMOTE_IP}:~/"
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely
-      command: echo remote-build-ghcjs
+      command: ssh -i "${CI_FILES}/hive-ci.pem" "ec2-user@${REMOTE_IP}" ./run-remote-build.sh
       no_output_timeout: 30m
   - &download-ghcjs-artifacts
     run:
@@ -149,7 +173,7 @@ jobs:
           at: .
       - restore_cache:
           key: *ghcjs-cache-key
-      - *install-terraform
+      - *install-remote-deps
       - *init-remote-server
       - *upload-ghcjs-cache
       - *remote-build-ghcjs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ aliases:
   - &remote-build-deps
     run:
       name: Build ghcjs dependencies
-      command: ssh "ec2-user@${REMOTE_IP}" sudo ./run-remote-build-deps.sh
+      command: ssh "ec2-user@${REMOTE_IP}" ./run-remote-build-deps.sh
       no_output_timeout: 30m
   - &download-ghcjs-cache
     run:
@@ -123,7 +123,7 @@ aliases:
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely
-      command: ssh "ec2-user@${REMOTE_IP}" sudo ./run-remote-build.sh
+      command: ssh "ec2-user@${REMOTE_IP}" ./run-remote-build.sh
   - &download-ghcjs-artifacts
     run:
       name: Download GHCJS build artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,13 @@ aliases:
         # wait for instance to boot up
         aws ec2 wait instance-running --filters "Name=ip-address,Values=${REMOTE_IP}"
 
-        # register host
+        # ignore key checking
         mkdir -p ~/.ssh && chmod 700 ~/.ssh
-        ssh-keyscan -H "$REMOTE_IP" >> ~/.ssh/known_hosts
+        cat >> ~/.ssh/config <<EOF
+        Host *
+            StrictHostKeyChecking no
+        EOF
+        chmod 400 ~/.ssh/config
       working_directory: /root/src/.circleci/
   - &upload-ghcjs-cache
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ aliases:
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely
-      command: ssh "ec2-user@${REMOTE_IP}" ./run-remote-build.sh
+      command: ssh "ec2-user@${REMOTE_IP}" sudo ./run-remote-build.sh
       no_output_timeout: 30m
   - &download-ghcjs-artifacts
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ aliases:
         chmod 400 ~/.ssh/config
 
         # wait for instance to boot up
-        aws ec2 wait instance-running --filters "Name=ip-address,Values=${REMOTE_IP}"
+        aws ec2 wait instance-status-ok --instance-ids "$(terraform output id)"
       working_directory: /root/src/.circleci/
   - &upload-remote-files
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - store_artifacts:
           path: build.tar.gz
 
-  hlint:
+  lint:
     <<: *docker-ghc
     steps:
       - checkout
@@ -161,15 +161,6 @@ jobs:
       - restore_cache:
           key: *ghc-cache-key
       - *run-hlint
-
-  stylish-haskell:
-    <<: *docker-ghc
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          key: *ghc-cache-key
       - *run-stylish-haskell
 
 workflows:
@@ -186,9 +177,6 @@ workflows:
           requires:
             - prebuild-ghcjs
             - build-ghc
-      - hlint:
-          requires:
-            - build-ghc
-      - stylish-haskell:
+      - lint:
           requires:
             - build-ghc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ aliases:
         # install ssh commands
         yum install -y openssh-clients
 
+        # install git command
+        yum install -y git
+
   # build steps
   - &run-build-ghc
     run:
@@ -92,11 +95,16 @@ aliases:
         # wait for instance to boot up
         aws ec2 wait instance-running --filters "Name=ip-address,Values=${REMOTE_IP}"
       working_directory: /root/src/.circleci/
-  - &upload-ghcjs-cache
+  - &upload-remote-files
     run:
-      name: Upload GHCJS cache
+      name: Upload files for building remotely
       command: |
-        FILES=( .circleci/run-remote-build.sh )
+        git archive HEAD | gzip > repo.tar.gz
+
+        FILES=(
+            .circleci/run-remote-build.sh
+            repo.tar.gz
+        )
         if [[ -f ~/ghcjs-cache.tar.gz ]]; then
           FILES+=( ~/ghcjs-cache.tar.gz )
         fi
@@ -109,7 +117,10 @@ aliases:
   - &download-ghcjs-artifacts
     run:
       name: Download GHCJS cache
-      command: echo download-ghcjs-artifacts
+      command: |
+        scp "ec2-user@${REMOTE_IP}:~/everything.tar.gz" .
+        tar xf everything.tar.gz
+      working_directory: /root/
   - &destroy-remote-server
     run:
       name: Terminate remote build server
@@ -175,7 +186,7 @@ jobs:
           key: *ghcjs-cache-key
       - *install-remote-deps
       - *init-remote-server
-      - *upload-ghcjs-cache
+      - *upload-remote-files
       - *remote-build-ghcjs
       - *download-ghcjs-artifacts
       - *destroy-remote-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,17 @@ aliases:
   - &init-remote-server
     run:
       name: Spin up remote build server
-      command: echo init-remote-server
+      command: |
+        terraform init
+        terraform apply --auto-approve
+
+        # get pem key
+        curl -O https://bootstrap.pypa.io/get-pip.py
+        python get-pip.py
+        pip install awscli
+        aws s3 cp s3://hive-ci/hive-ci.pem .
+        chmod 600 hive-ci.pem
+      working_directory: /root/src/.circleci/
   - &upload-ghcjs-cache
     run:
       name: Upload GHCJS cache
@@ -79,7 +89,9 @@ aliases:
   - &destroy-remote-server
     run:
       name: Terminate remote build server
-      command: echo destroy-remote-server
+      command: terraform destroy --auto-approve
+      working_directory: /root/src/.circleci/
+      when: always
 
   # test steps
   - &run-hlint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ aliases:
         )
         cat "${FILES[@]}" > ghcjs-cache-key.txt
   - &ghc-cache-key
-    v0-{{ checksum "ghc-cache-key.txt" }}
+    v1-{{ checksum "ghc-cache-key.txt" }}
   - &ghcjs-cache-key
-    v0.2-{{ checksum "ghcjs-cache-key.txt" }}
+    v1-{{ checksum "ghcjs-cache-key.txt" }}
 
   # dependencies
   - &install-system-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
   - &ghc-cache-key
     v0-{{ checksum "ghc-cache-key.txt" }}
   - &ghcjs-cache-key
-    v0.1-{{ checksum "ghcjs-cache-key.txt" }}
+    v0.2-{{ checksum "ghcjs-cache-key.txt" }}
 
   # dependencies
   - &install-system-deps
@@ -101,10 +101,12 @@ aliases:
     run:
       name: Upload GHCJS cache
       command: |
-        scp -i "${CI_FILES}/hive-ci.pem" \
-          ~/ghcjs-cache.tar.gz \
-          .circleci/run-remote-build.sh \
-          "ec2-user@${REMOTE_IP}:~/"
+        if [[ -f ~/ghcjs-cache.tar.gz ]]; then
+          scp -i "${CI_FILES}/hive-ci.pem" \
+            ~/ghcjs-cache.tar.gz \
+            .circleci/run-remote-build.sh \
+            "ec2-user@${REMOTE_IP}:~/"
+        fi
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ aliases:
       name: Build stack dependencies
       command: scripts/install-stack-deps.sh
       no_output_timeout: 30m
+  - &install-terraform
+    run:
+      name: Install Terraform
+      command: scripts/install-terraform.sh
 
   # build steps
   - &run-build-ghc
@@ -133,6 +137,7 @@ jobs:
           at: .
       - restore_cache:
           key: *ghcjs-cache-key
+      - *install-terraform
       - *init-remote-server
       - *upload-ghcjs-cache
       - *remote-build-ghcjs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,25 +103,31 @@ aliases:
         git archive HEAD | gzip > repo.tar.gz
 
         FILES=(
+            .circleci/run-remote-build-deps.sh
             .circleci/run-remote-build.sh
             repo.tar.gz
         )
-        if [[ -f ~/ghcjs-cache.tar.gz ]]; then
-          FILES+=( ~/ghcjs-cache.tar.gz )
+        if [[ -f ghcjs-cache.tar.gz ]]; then
+          FILES+=( ghcjs-cache.tar.gz )
         fi
         scp "${FILES[@]}" "ec2-user@${REMOTE_IP}:~/"
+  - &remote-build-deps
+    run:
+      name: Build ghcjs dependencies
+      command: ssh "ec2-user@${REMOTE_IP}" sudo ./run-remote-build-deps.sh
+      no_output_timeout: 30m
+  - &download-ghcjs-cache
+    run:
+      name: Download GHCJS cache
+      command: scp "ec2-user@${REMOTE_IP}:~/ghcjs-cache.tar.gz" .
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely
       command: ssh "ec2-user@${REMOTE_IP}" sudo ./run-remote-build.sh
-      no_output_timeout: 30m
   - &download-ghcjs-artifacts
     run:
-      name: Download GHCJS cache
-      command: |
-        scp "ec2-user@${REMOTE_IP}:~/everything.tar.gz" .
-        tar xf everything.tar.gz
-      working_directory: /root/
+      name: Download GHCJS build artifacts
+      command: scp "ec2-user@${REMOTE_IP}:~/build.tar.gz" .
   - &destroy-remote-server
     run:
       name: Terminate remote build server
@@ -188,15 +194,17 @@ jobs:
       - *install-remote-deps
       - *init-remote-server
       - *upload-remote-files
-      - *remote-build-ghcjs
-      - *download-ghcjs-artifacts
-      - *destroy-remote-server
+      - *remote-build-deps
+      - *download-ghcjs-cache
       - save_cache:
           key: *ghcjs-cache-key
           paths:
-            - ~/ghcjs-cache.tar.gz
+            - ghcjs-cache.tar.gz
+      - *remote-build-ghcjs
+      - *download-ghcjs-artifacts
       - store_artifacts:
           path: build.tar.gz
+      - *destroy-remote-server
 
   lint:
     <<: *docker-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,24 +88,16 @@ aliases:
       command: scripts/stylish-haskell.sh
 
 jobs:
-  prebuild-ghc:
+  prebuild:
     <<: *docker-linux
     steps:
       - checkout
       - *build-ghc-cache-key
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ghc-cache-key.txt
-
-  prebuild-ghcjs:
-    <<: *docker-linux
-    steps:
-      - checkout
       - *build-ghcjs-cache-key
       - persist_to_workspace:
           root: .
           paths:
+            - ghc-cache-key.txt
             - ghcjs-cache-key.txt
 
   build-ghc:
@@ -169,14 +161,13 @@ workflows:
 
   build_and_test:
     jobs:
-      - prebuild-ghc
-      - prebuild-ghcjs
+      - prebuild
       - build-ghc:
           requires:
-            - prebuild-ghc
+            - prebuild
       - build-ghcjs:
           requires:
-            - prebuild-ghcjs
+            - prebuild
       - lint:
           requires:
             - build-ghc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,6 @@ aliases:
     docker:
       - image: centos:7
     working_directory: /root/src
-  - &docker-ghc
-    <<: *docker-linux
-    environment:
-      NO_GHCJS: true
-  - &docker-ghcjs
-    <<: *docker-linux
-    environment:
-      NO_GHC: true
 
   # caches
   - &build-ghc-cache-key
@@ -43,11 +35,6 @@ aliases:
     v0-{{ checksum "ghc-cache-key.txt" }}
   - &ghcjs-cache-key
     v0-{{ checksum "ghcjs-cache-key.txt" }}
-  - &cache-paths
-    - ~/.stack
-    - ~/.ghcjs
-    - /usr/local/bin
-    - /usr/local/lib/node
 
   # dependencies
   - &install-system-deps
@@ -66,13 +53,29 @@ aliases:
       name: Build package
       command: stack build --test --no-run-tests
       no_output_timeout: 30m
-  - &run-build-ghcjs
+
+  # ghcjs steps
+  - &init-remote-server
     run:
-      name: Build package
-      command: |
-        ghcjs/build.sh --test --no-run-tests
-        tar czf build.tar.gz build/
+      name: Spin up remote build server
+      command: echo init-remote-server
+  - &upload-ghcjs-cache
+    run:
+      name: Upload GHCJS cache
+      command: echo upload-ghcjs-cache
+  - &remote-build-ghcjs
+    run:
+      name: Build with ghcjs remotely
+      command: echo remote-build-ghcjs
       no_output_timeout: 30m
+  - &download-ghcjs-artifacts
+    run:
+      name: Download GHCJS cache
+      command: echo download-ghcjs-artifacts
+  - &destroy-remote-server
+    run:
+      name: Terminate remote build server
+      command: echo destroy-remote-server
 
   # test steps
   - &run-hlint
@@ -86,7 +89,7 @@ aliases:
 
 jobs:
   prebuild-ghc:
-    <<: *docker-ghc
+    <<: *docker-linux
     steps:
       - checkout
       - *build-ghc-cache-key
@@ -96,7 +99,7 @@ jobs:
             - ghc-cache-key.txt
 
   prebuild-ghcjs:
-    <<: *docker-ghcjs
+    <<: *docker-linux
     steps:
       - checkout
       - *build-ghcjs-cache-key
@@ -106,7 +109,7 @@ jobs:
             - ghcjs-cache-key.txt
 
   build-ghc:
-    <<: *docker-ghc
+    <<: *docker-linux
     steps:
       - checkout
       - attach_workspace:
@@ -118,7 +121,11 @@ jobs:
       - *install-stack-deps
       - save_cache:
           key: *ghc-cache-key
-          paths: *cache-paths
+          paths:
+            - ~/.stack
+            - ~/.ghcjs
+            - /usr/local/bin
+            - /usr/local/lib/node
       # build
       - *run-build-ghc
       - persist_to_workspace:
@@ -127,33 +134,27 @@ jobs:
               - .stack-work
 
   build-ghcjs:
-    <<: *docker-ghcjs
+    <<: *docker-linux
     steps:
       - checkout
       - attach_workspace:
           at: .
-      # dependencies
-      - restore_cache:
-          key: *ghc-cache-key
       - restore_cache:
           key: *ghcjs-cache-key
-      - *install-system-deps
-      - *install-stack-deps
+      - *init-remote-server
+      - *upload-ghcjs-cache
+      - *remote-build-ghcjs
+      - *download-ghcjs-artifacts
+      - *destroy-remote-server
       - save_cache:
           key: *ghcjs-cache-key
-          paths: *cache-paths
-      # build
-      - *run-build-ghcjs
-      - persist_to_workspace:
-          root: .
           paths:
-              - ghcjs/.stack-work
-              - build/
+            - ~/ghcjs-cache.tar.gz
       - store_artifacts:
           path: build.tar.gz
 
   lint:
-    <<: *docker-ghc
+    <<: *docker-linux
     steps:
       - checkout
       - attach_workspace:
@@ -176,7 +177,6 @@ workflows:
       - build-ghcjs:
           requires:
             - prebuild-ghcjs
-            - build-ghc
       - lint:
           requires:
             - build-ghc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ aliases:
     docker:
       - image: centos:7
     working_directory: /root/src
-    environment:
-      CI_FILES: /root/.ci/
 
   # caches
   - &build-ghc-cache-key
@@ -75,42 +73,38 @@ aliases:
     run:
       name: Spin up remote build server
       command: |
-        mkdir -p "$CI_FILES"
-
         terraform init
         terraform apply --auto-approve
         REMOTE_IP=$(terraform output ip)
         echo "export REMOTE_IP=${REMOTE_IP}" >> "$BASH_ENV"
 
-        # get pem key
-        aws s3 cp s3://hive-ci/hive-ci.pem "$CI_FILES"
-        chmod 600 "${CI_FILES}/hive-ci.pem"
+        # setup ssh
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        aws s3 cp s3://hive-ci/hive-ci.pem ~/.ssh/
+        chmod 600 ~/.ssh/hive-ci.pem
+        cat >> ~/.ssh/config <<EOF
+        Host ${REMOTE_IP}
+            StrictHostKeyChecking no
+            IdentityFile ~/.ssh/hive-ci.pem
+        EOF
+        chmod 400 ~/.ssh/config
 
         # wait for instance to boot up
         aws ec2 wait instance-running --filters "Name=ip-address,Values=${REMOTE_IP}"
-
-        # ignore key checking
-        mkdir -p ~/.ssh && chmod 700 ~/.ssh
-        cat >> ~/.ssh/config <<EOF
-        Host *
-            StrictHostKeyChecking no
-        EOF
-        chmod 400 ~/.ssh/config
       working_directory: /root/src/.circleci/
   - &upload-ghcjs-cache
     run:
       name: Upload GHCJS cache
       command: |
+        FILES=( .circleci/run-remote-build.sh )
         if [[ -f ~/ghcjs-cache.tar.gz ]]; then
-          scp -i "${CI_FILES}/hive-ci.pem" \
-            ~/ghcjs-cache.tar.gz \
-            .circleci/run-remote-build.sh \
-            "ec2-user@${REMOTE_IP}:~/"
+          FILES+=( ~/ghcjs-cache.tar.gz )
         fi
+        scp "${FILES[@]}" "ec2-user@${REMOTE_IP}:~/"
   - &remote-build-ghcjs
     run:
       name: Build with ghcjs remotely
-      command: ssh -i "${CI_FILES}/hive-ci.pem" "ec2-user@${REMOTE_IP}" ./run-remote-build.sh
+      command: ssh "ec2-user@${REMOTE_IP}" ./run-remote-build.sh
       no_output_timeout: 30m
   - &download-ghcjs-artifacts
     run:

--- a/.circleci/run-remote-build-deps.sh
+++ b/.circleci/run-remote-build-deps.sh
@@ -7,8 +7,8 @@ tar xf repo.tar.gz
 
 if [[ -f ghcjs-cache.tar.gz ]]; then
     tar xf ghcjs-cache.tar.gz
-    mv usr-bin /usr/local/bin/
-    mv usr-lib /usr/local/lib/
+    sudo mv usr-bin/* /usr/local/bin/
+    sudo mv usr-lib/* /usr/local/lib/
     rm ghcjs-cache.tar.gz
 fi
 

--- a/.circleci/run-remote-build-deps.sh
+++ b/.circleci/run-remote-build-deps.sh
@@ -13,8 +13,8 @@ if [[ -f ghcjs-cache.tar.gz ]]; then
 fi
 
 export PATH=/usr/local/bin:$PATH
-chown -R $USER:$USER .
 
+sudo chown -R $USER:$USER /usr/local/
 scripts/install-system-deps.sh
 scripts/install-stack-deps.sh
 stack build alex happy
@@ -22,7 +22,6 @@ ghcjs/stack.sh setup
 ghcjs/stack.sh build --only-dependencies
 
 # pack cache
-mv ~/.stack ~/.ghcjs .
 mv /usr/local/bin/ usr-bin
 mv /usr/local/lib/ usr-lib
 tar czf ghcjs-cache.tar.gz \

--- a/.circleci/run-remote-build-deps.sh
+++ b/.circleci/run-remote-build-deps.sh
@@ -16,14 +16,13 @@ export PATH=/usr/local/bin:$PATH
 
 sudo chown -R $USER:$USER /usr/local/
 scripts/install-system-deps.sh
-scripts/install-stack-deps.sh
 stack build alex happy
 ghcjs/stack.sh setup
 ghcjs/stack.sh build --only-dependencies
 
 # pack cache
-mv /usr/local/bin/ usr-bin
-mv /usr/local/lib/ usr-lib
+cp -r /usr/local/bin/ usr-bin
+cp -r /usr/local/lib/ usr-lib
 tar czf ghcjs-cache.tar.gz \
     .stack \
     .ghcjs \

--- a/.circleci/run-remote-build-deps.sh
+++ b/.circleci/run-remote-build-deps.sh
@@ -12,8 +12,6 @@ if [[ -f ghcjs-cache.tar.gz ]]; then
     rm ghcjs-cache.tar.gz
 fi
 
-export PATH=/usr/local/bin:$PATH
-
 sudo chown -R $USER:$USER /usr/local/
 scripts/install-system-deps.sh
 stack build alex happy

--- a/.circleci/run-remote-build-deps.sh
+++ b/.circleci/run-remote-build-deps.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# unpack files
+tar xf repo.tar.gz
+
+if [[ -f ghcjs-cache.tar.gz ]]; then
+    tar xf ghcjs-cache.tar.gz
+    mv usr-bin /usr/local/bin/
+    mv usr-lib /usr/local/lib/
+    rm ghcjs-cache.tar.gz
+fi
+
+export PATH=/usr/local/bin:$PATH
+chown -R $USER:$USER .
+
+scripts/install-system-deps.sh
+scripts/install-stack-deps.sh
+stack build alex happy
+ghcjs/stack.sh setup
+ghcjs/stack.sh build --only-dependencies
+
+# pack cache
+mv ~/.stack ~/.ghcjs .
+mv /usr/local/bin/ usr-bin
+mv /usr/local/lib/ usr-lib
+tar czf ghcjs-cache.tar.gz \
+    .stack \
+    .ghcjs \
+    usr-bin \
+    usr-lib

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -2,5 +2,7 @@
 
 set -eux -o pipefail
 
+export PATH=/usr/local/bin:$PATH
+
 ghcjs/build.sh
 tar czf build.tar.gz build/

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -12,7 +12,7 @@ if [[ -f ghcjs-cache.tar.gz ]]; then
     rm ghcjs-cache.tar.gz
 fi
 
-sudo scripts/install-system-deps.sh
+sudo bash -c 'PATH=$PATH:/usr/local/bin scripts/install-system-deps.sh'
 scripts/install-stack-deps.sh
 stack build alex happy
 ghcjs/stack.sh setup

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -2,36 +2,5 @@
 
 set -eux -o pipefail
 
-# unpack files
-tar xf repo.tar.gz
-
-if [[ -f ghcjs-cache.tar.gz ]]; then
-    tar xf ghcjs-cache.tar.gz
-    mv usr-bin /usr/local/bin/
-    mv usr-lib /usr/local/lib/
-    rm ghcjs-cache.tar.gz
-fi
-
-export PATH=/usr/local/bin:$PATH
-chown -R $USER:$USER .
-
-scripts/install-system-deps.sh
-scripts/install-stack-deps.sh
-stack build alex happy
-ghcjs/stack.sh setup
-ghcjs/stack.sh build --only-dependencies
-
-# pack cache
-mv ~/.stack ~/.ghcjs .
-mv /usr/local/bin/ usr-bin
-mv /usr/local/lib/ usr-lib
-tar czf ghcjs-cache.tar.gz \
-    .stack \
-    .ghcjs \
-    usr-bin \
-    usr-lib
-
 ghcjs/build.sh
 tar czf build.tar.gz build/
-
-tar czf everything.tar.gz build.tar.gz ghcjs-cache.tar.gz

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -12,7 +12,10 @@ if [[ -f ghcjs-cache.tar.gz ]]; then
     rm ghcjs-cache.tar.gz
 fi
 
-sudo bash -c 'PATH=$PATH:/usr/local/bin scripts/install-system-deps.sh'
+export PATH=/usr/local/bin:$PATH
+chown -R $USER:$USER .
+
+scripts/install-system-deps.sh
 scripts/install-stack-deps.sh
 stack build alex happy
 ghcjs/stack.sh setup

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 
-set -eu -o pipefail
+set -eux -o pipefail
 
-ls
+# unpack files
+tar xf repo.tar.gz
 
 if [[ -f ghcjs-cache.tar.gz ]]; then
-    tar tf ghcjs-cache.tar.gz
+    tar xf ghcjs-cache.tar.gz
+    mv usr-bin /usr/local/bin/
+    mv usr-lib /usr/local/lib/
+    rm ghcjs-cache.tar.gz
 fi
+
+sudo scripts/install-system-deps.sh
+scripts/install-stack-deps.sh
+stack build alex happy
+ghcjs/stack.sh setup
+ghcjs/stack.sh build --only-dependencies
+
+# pack cache
+mv /usr/local/bin/ usr-bin
+mv /usr/local/lib/ usr-lib
+tar czf ghcjs-cache.tar.gz \
+    .stack \
+    .ghcjs \
+    usr-bin \
+    usr-lib
+
+ghcjs/build.sh
+tar czf build.tar.gz build/
+
+tar czf everything.tar.gz build.tar.gz ghcjs-cache.tar.gz

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -3,4 +3,7 @@
 set -eu -o pipefail
 
 ls
-tar tf ghcjs-cache.tar.gz
+
+if [[ -f ghcjs-cache.tar.gz ]]; then
+    tar tf ghcjs-cache.tar.gz
+fi

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -22,6 +22,7 @@ ghcjs/stack.sh setup
 ghcjs/stack.sh build --only-dependencies
 
 # pack cache
+mv ~/.stack ~/.ghcjs .
 mv /usr/local/bin/ usr-bin
 mv /usr/local/lib/ usr-lib
 tar czf ghcjs-cache.tar.gz \

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+ls
+tar tf ghcjs-cache.tar.gz

--- a/.circleci/run-remote-build.sh
+++ b/.circleci/run-remote-build.sh
@@ -2,7 +2,5 @@
 
 set -eux -o pipefail
 
-export PATH=/usr/local/bin:$PATH
-
 ghcjs/build.sh
 tar czf build.tar.gz build/

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "ci_build" {
 }
 
 resource "aws_security_group" "allow_all" {
-  name = "allow_all"
+  name_prefix = "allow-all-"
   ingress {
     from_port = 0
     to_port = 0

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -23,6 +23,12 @@ resource "aws_security_group" "allow_all" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 output "ip" {

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_instance" "ci_build" {
+  ami = "ami-28e07e50" # RHEL 7.5
+  instance_type = "t3.medium"
+  key_name = "hive-ci"
+  security_groups = [
+    "${aws_security_group.allow_all.name}",
+  ]
+
+  tags {
+    Name = "Hive CI Build"
+  }
+}
+
+resource "aws_security_group" "allow_all" {
+  name = "allow_all"
+  ingress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+output "ip" {
+  value = "${aws_instance.ci_build.public_ip}"
+}

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -38,3 +38,7 @@ resource "aws_security_group" "allow_all" {
 output "ip" {
   value = "${aws_instance.ci_build.public_ip}"
 }
+
+output "id" {
+  value = "${aws_instance.ci_build.id}"
+}

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 resource "aws_instance" "ci_build" {
   ami = "ami-28e07e50" # RHEL 7.5
-  instance_type = "t3.medium"
+  instance_type = "t3.large"
   key_name = "hive-ci"
   security_groups = [
     "${aws_security_group.allow_all.name}",

--- a/.circleci/terraform.tf
+++ b/.circleci/terraform.tf
@@ -10,6 +10,10 @@ resource "aws_instance" "ci_build" {
     "${aws_security_group.allow_all.name}",
   ]
 
+  root_block_device {
+    volume_size = 25
+  }
+
   tags {
     Name = "Hive CI Build"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Build artifacts
 build/
+
+# Terraform artifacts
+.terraform/
+terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ build/
 
 # Terraform artifacts
 .terraform/
-terraform.tfstate*
+*terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ build/
 # Terraform artifacts
 .terraform/
 terraform.tfstate*
-
-# Private keys
-*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 # Terraform artifacts
 .terraform/
 terraform.tfstate*
+
+# Private keys
+*.pem

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The project is set up to work for both `ghc` and `ghcjs`. It's faster to
 develop with `ghc`, so just use `stack build` to build and
 `stack exec hive` to start running the server.
 
+### GHCJS
+
+To set up your system to build with ghcjs, run the following steps:
+
+1. `stack build alex happy` (These executables are needed by GHCJS)
+1. `ghcjs/stack.sh setup` (This step will take a long time the first time)
+1. `ghcjs/stack.sh build --only-dependencies`
+
 To run stack with `ghcjs`, use the `ghcjs/stack.sh` script. To imitate a
 deployment build, run `ghcjs/build.sh`, which will compile the static files
 to `build/`.

--- a/ghcjs/stack.sh
+++ b/ghcjs/stack.sh
@@ -8,6 +8,4 @@ builtin cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 export PATH=$PATH:$(stack path --snapshot-install-root)/bin:$(stack path --compiler-bin)
 
-if [[ "${NO_GHCJS:-}" != "true" ]]; then
-    stack --stack-yaml=ghcjs/stack.yaml "$@"
-fi
+stack --stack-yaml=ghcjs/stack.yaml "$@"

--- a/scripts/install-stack-deps.sh
+++ b/scripts/install-stack-deps.sh
@@ -4,11 +4,5 @@
 
 set -e
 
-if [[ "${NO_GHC:-}" != "true" ]]; then
-    stack build --test --only-dependencies
-fi
-
-# needs to be installed explicitly first for linux
-ghcjs/stack.sh build ghcjs-dom-jsffi
-ghcjs/stack.sh build --test --only-dependencies
+stack build --test --only-dependencies
 stack build hlint stylish-haskell

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -84,11 +84,6 @@ install_stack() {
 
     stack --version
     stack setup
-
-    # Tools needed for GHCJS
-    stack build alex happy
-
-    ghcjs/stack.sh setup
 }
 
 case $(uname) in

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -41,7 +41,12 @@ setup_linux() {
         # ghcjs
         ncurses-devel
     )
-    yum install -y "${YUM_PACKAGES[@]}"
+    if type sudo &> /dev/null; then
+        CMD="sudo"
+    else
+        CMD="command"
+    fi
+    "$CMD" yum install -y "${YUM_PACKAGES[@]}"
 
     mkdir -p ~/.bin
 

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -5,6 +5,7 @@
 set -eux -o pipefail
 
 CABAL_BASE_URL=https://www.haskell.org/cabal/release/cabal-install-1.24.0.2
+HERE=$(builtin cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 is_command() {
     type "$1" &> /dev/null

--- a/scripts/install-terraform.sh
+++ b/scripts/install-terraform.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Install Terraform
+
+set -eux -o pipefail
+
+is_command() {
+    type "$1" &> /dev/null
+}
+
+case $(uname) in
+    (Darwin) PLATFORM=darwin ;;
+    (Linux)
+        PLATFORM=linux
+        yum install -y unzip
+    ;;
+esac
+
+NAME=terraform_0.11.8_${PLATFORM}_amd64
+
+if ! is_command terraform; then
+    curl -LO "https://releases.hashicorp.com/terraform/0.11.8/${NAME}.zip"
+    unzip "${NAME}.zip"
+    rm "${NAME}.zip"
+    mv terraform /usr/local/bin
+fi
+
+terraform --version


### PR DESCRIPTION
Circle CI's docker containers aren't allocated enough memory required by building with GHCJS. This PR will spin up an EC2 instance for every CI run, copy everything onto it, build remotely, and copy artifacts back.